### PR TITLE
libgcrypt 1.12.1 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "libgcrypt" %}
-{% set version = "1.11.2" %}
+{% set version = "1.12.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://gnupg.org/ftp/gcrypt/{{ name }}/{{ name }}-{{ version }}.tar.bz2
-  sha256: 6ba59dd192270e8c1d22ddb41a07d95dcdbc1f0fb02d03c4b54b235814330aac
+  sha256: 7df5c08d952ba33f9b6bdabdb06a61a78b2cf62d2122c2d1d03a91a79832aa3c
 
 build:
   number: 0
@@ -22,7 +22,7 @@ requirements:
     - make     # [unix]
     - libtool  # [unix]
   host:
-    - libgpg-error 1.51
+    - libgpg-error 1.58
 
 test:
   commands:


### PR DESCRIPTION
libgcrypt 1.12.1 

**Destination channel:** Defaults

### Links

- [PKG-12594]
- dev_url:        https://github.com/gpg/libgcrypt/tree/libgcrypt-1.12.1
- conda_forge:    https://github.com/conda-forge/libgcrypt-feedstock
- pypi:           https://www.google.com/
- pypi inspector: https://www.google.com/

### Explanation of changes:

- new version number


[PKG-12594]: https://anaconda.atlassian.net/browse/PKG-12594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ